### PR TITLE
Infrastructure: Added correlation id to logs

### DIFF
--- a/PTW-API/Contracts/ICorrelationIdGenerator.cs
+++ b/PTW-API/Contracts/ICorrelationIdGenerator.cs
@@ -1,0 +1,10 @@
+﻿namespace PTW_API.Contracts
+{
+    public interface ICorrelationIdGenerator
+    {
+        string Get();
+
+        void Set(string correlationId);
+
+    }
+}

--- a/PTW-API/Middlewares/CorrelationIdMiddleware.cs
+++ b/PTW-API/Middlewares/CorrelationIdMiddleware.cs
@@ -1,0 +1,22 @@
+﻿namespace PTW_API.Middlewares
+{
+    using PTW_API.Contracts;
+
+    public class CorrelationIdMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public CorrelationIdMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context, ICorrelationIdGenerator correlationIdGenerator)
+        {
+            using (Correlator.BeginCorrelationScope(correlationIdGenerator.Get()))
+            {
+                await _next.Invoke(context);
+            }
+        }
+    }
+}

--- a/PTW-API/PTW-API.csproj
+++ b/PTW-API/PTW-API.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="MySqlConnector" Version="2.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.4" />

--- a/PTW-API/Program.cs
+++ b/PTW-API/Program.cs
@@ -35,6 +35,8 @@ else
     app.UseHsts();
 }
 
+app.AddPTWMiddlewares();
+
 app.MapControllers();
 
 app.UseStaticFiles()

--- a/PTW-API/Services/ConfigureJobs.cs
+++ b/PTW-API/Services/ConfigureJobs.cs
@@ -5,6 +5,7 @@
     using Newtonsoft.Json;
     using PTW_API.Contracts;
     using PTW_API.Filters;
+    using PTW_API.Services.ForecastUpdaterService.Abstraction;
     using TimeZoneConverter;
 
     public static class ConfigureJobs

--- a/PTW-API/Services/CorrelationIdGenerator.cs
+++ b/PTW-API/Services/CorrelationIdGenerator.cs
@@ -1,0 +1,16 @@
+﻿using PTW_API.Contracts;
+
+namespace PTW_API.Services
+{
+    public class CorrelationIdGenerator : ICorrelationIdGenerator
+    {
+        private string _correlationId = Guid.NewGuid().ToString();
+
+        public string Get() => _correlationId;
+
+        public void Set(string correlationId)
+        {
+            _correlationId = correlationId;
+        }
+    }
+}

--- a/PTW-API/Services/ForecastUpdaterService/Abstraction/IForecastService.cs
+++ b/PTW-API/Services/ForecastUpdaterService/Abstraction/IForecastService.cs
@@ -1,4 +1,4 @@
-﻿namespace PTW_API.Services
+﻿namespace PTW_API.Services.ForecastUpdaterService.Abstraction
 {
     using PTW.Domain.Storage.Forecast.Domain;
 

--- a/PTW-API/Services/ForecastUpdaterService/Implementation/ForecastUpdaterService.cs
+++ b/PTW-API/Services/ForecastUpdaterService/Implementation/ForecastUpdaterService.cs
@@ -1,8 +1,9 @@
-﻿namespace PTW_API.Services
+﻿namespace PTW_API.Services.ForecastUpdaterService.Implementation
 {
     using PTW_API.Contracts;
     using System.Threading.Tasks;
     using PTW.Domain.Storage.Forecast.Domain;
+    using PTW_API.Services.ForecastUpdaterService.Abstraction;
     using PTW.Domain.Storage.Forecast.Repositories.Abstractions;
 
     public class ForecastUpdaterService : IForecastUpdaterService

--- a/PTW-API/Services/RegisterMiddlewares.cs
+++ b/PTW-API/Services/RegisterMiddlewares.cs
@@ -1,0 +1,14 @@
+﻿using PTW_API.Middlewares;
+
+namespace PTW_API.Services
+{
+    public static class RegisterMiddlewares
+    {
+        public static IApplicationBuilder AddPTWMiddlewares(this IApplicationBuilder applicationBuilder)
+        {
+            applicationBuilder.UseMiddleware<CorrelationIdMiddleware>();
+
+            return applicationBuilder;
+        }
+    }
+}

--- a/PTW-API/Services/RegisterServices.cs
+++ b/PTW-API/Services/RegisterServices.cs
@@ -2,12 +2,14 @@
 {
     using PTW.Domain.Storage.Forecast.Repositories.Abstractions;
     using PTW.Domain.Storage.Forecast.Repositories.Implementations;
+    using PTW_API.Contracts;
 
     public static class RegisterServices
     {
         public static IServiceCollection AddPTWServices(this IServiceCollection services)
         {
             services.AddScoped<IForecastRepository, ForecastRepository>();
+            services.AddScoped<ICorrelationIdGenerator, CorrelationIdGenerator>();
 
             return services;
         }

--- a/PTW-API/Services/Utils/Logging/Correlator.cs
+++ b/PTW-API/Services/Utils/Logging/Correlator.cs
@@ -1,0 +1,35 @@
+﻿namespace PTW_API.Services.Utils.Logging
+{
+    using Serilog.Context;
+
+    public static class Correlator
+    {
+        private static AsyncLocal<string> CorrelationId = new AsyncLocal<string>();
+
+        public static string CurrentCorrelationId => CorrelationId.Value ?? "";
+
+        public static IDisposable BeginCorrelationScope(string correlationId)
+        {
+            if (CorrelationId.Value != null)
+            {
+                throw new InvalidOperationException("Already is an operation.");
+            }
+
+            CorrelationId.Value = correlationId;
+
+            return new CorrelationScope(LogContext.PushProperty("CorrelationId", correlationId));
+        }
+
+        private class CorrelationScope : IDisposable
+        {
+            private readonly IDisposable _logContextPop;
+            
+            public CorrelationScope(IDisposable logContextPop)
+            {
+                _logContextPop = logContextPop ?? throw new ArgumentNullException(nameof(logContextPop));
+            }
+
+            public void Dispose() => _logContextPop.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces correlation id to logs, which can be used to follow the flow of a request through the application.